### PR TITLE
Add nearby users bloc feature

### DIFF
--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -52,11 +52,12 @@ class DatabaseHelper {
       {'name': 'Alice', 'username': 'alice123'},
       {'name': 'Bob', 'username': 'bob456'},
       {'name': 'Charlie', 'username': 'charlie789'},
+      {'id': 'b01b1320-6660-4076-b847-c675ce8cb5f7', 'name': 'Charlie', 'username': 'charlie789'},
     ];
 
     for (var user in dummyUsers) {
       await db.insert('users', {
-        'id': _uuid.v4(),
+        'id': user['id'] ?? _uuid.v4(),
         'name': user['name']!,
         'username': user['username']!,
       });

--- a/lib/features/nearby_users/data/nearby_repository.dart
+++ b/lib/features/nearby_users/data/nearby_repository.dart
@@ -1,0 +1,67 @@
+import 'package:mesh_mobile/database/database_helper.dart';
+import 'package:mesh_mobile/features/nearby_users/domain/nearby_user_summary.dart';
+
+class NearbyRepository {
+  Future<NearbyUserSummary> fetchNearbyUserSummary(String userId) async {
+    final dbClient = await DatabaseHelper.db;
+
+    final result = await dbClient.rawQuery('''
+        SELECT 
+            u.id AS userId,
+            u.name,
+            u.username,
+            (
+                SELECT chatId
+                FROM messages
+                WHERE (messages.senderId = u.id OR messages.chatId LIKE '%' || u.id || '%')
+                ORDER BY timestamp DESC
+                LIMIT 1
+            ) AS chatId,
+            (
+                SELECT content
+                FROM messages
+                WHERE (messages.senderId = u.id OR messages.chatId LIKE '%' || u.id || '%')
+                ORDER BY timestamp DESC
+                LIMIT 1
+            ) AS lastMessage,
+            (
+                SELECT timestamp
+                FROM messages
+                WHERE (messages.senderId = u.id OR messages.chatId LIKE '%' || u.id || '%')
+                ORDER BY timestamp DESC
+                LIMIT 1
+            ) AS lastMessageTime
+        FROM users u
+        WHERE u.id = ?
+        LIMIT 1;
+    ''', [userId]);
+
+    if (result.isNotEmpty) {
+      final row = result.first;
+      return NearbyUserSummary(
+        userId: row['userId'] as String,
+        name: row['name'] as String,
+        username: row['username'] as String,
+        initial: (row['name'] as String).isNotEmpty
+            ? (row['name'] as String)[0]
+            : "-",
+        lastMessage: (row['lastMessage'] ?? 'No messages yet') as String,
+        lastMessageTime: row['lastMessageTime'] != null
+            ? DateTime.parse(row['lastMessageTime'] as String)
+            : null,
+        isOnline: false, // Placeholder, update with actual online status logic
+      );
+    } else {
+      // Return dummy data if the user does not exist
+      return NearbyUserSummary(
+        userId: userId,
+        name: 'Unknown User',
+        username: 'unknown',
+        initial: "-",
+        lastMessage: null,
+        lastMessageTime: null,
+        isOnline: false,
+      );
+    }
+  }
+}

--- a/lib/features/nearby_users/domain/nearby_user_summary.dart
+++ b/lib/features/nearby_users/domain/nearby_user_summary.dart
@@ -1,0 +1,34 @@
+import 'package:equatable/equatable.dart';
+
+class NearbyUserSummary extends Equatable {
+  final String name;
+  final String userId;
+  final String username;
+  final String initial;
+  final bool isOnline;
+  final int unreadCount;
+  final String? lastMessage;
+  final DateTime? lastMessageTime;
+
+  const NearbyUserSummary({
+    required this.userId,
+    required this.name,
+    required this.username,
+    required this.initial,
+    required this.isOnline,
+    this.lastMessage,
+    this.lastMessageTime,
+    this.unreadCount = 0,
+  });
+
+  @override
+  List<Object?> get props => [
+        username,
+        name,
+        lastMessage,
+        lastMessageTime,
+        initial,
+        isOnline,
+        unreadCount
+      ];
+}

--- a/lib/features/nearby_users/presentation/bloc/nearby_users_bloc.dart
+++ b/lib/features/nearby_users/presentation/bloc/nearby_users_bloc.dart
@@ -1,0 +1,42 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mesh_mobile/features/nearby_users/data/nearby_repository.dart';
+import 'package:mesh_mobile/features/nearby_users/domain/nearby_user_summary.dart';
+
+part 'nearby_users_event.dart';
+part 'nearby_users_state.dart';
+
+class NearbyUsersBloc extends Bloc<NearbyUsersEvent, NearbyUsersState> {
+  final NearbyRepository nearbyRepository;
+
+  NearbyUsersBloc({required this.nearbyRepository})
+      : super(NearbyUsersInitial()) {
+    on<LoadNearbyUsers>(_onLoadNearbyUsers);
+  }
+
+  Future<void> _onLoadNearbyUsers(
+    LoadNearbyUsers event,
+    Emitter<NearbyUsersState> emit,
+  ) async {
+    emit(NearbyUsersLoading());
+
+    final userIds = [
+      "b01b1320-6660-4076-b847-c675ce8cb5f7",
+      "1e184d65-ba62-40ca-a146-4192369af4ec",
+      "032c9ca4-04e5-43b7-8c2e-56edbab33fa4",
+    ];
+
+    try {
+      final List<NearbyUserSummary> nearbyUsers = await Future.wait(
+        userIds.map((userId) async {
+          return await nearbyRepository.fetchNearbyUserSummary(userId);
+        }),
+      );
+
+      emit(NearbyUsersLoaded(nearbyUsers));
+    } catch (e) {
+      emit(NearbyUsersError(
+          'Failed to get Nearby Devices, Exception: ${e.toString()}'));
+    }
+  }
+}

--- a/lib/features/nearby_users/presentation/bloc/nearby_users_event.dart
+++ b/lib/features/nearby_users/presentation/bloc/nearby_users_event.dart
@@ -1,0 +1,10 @@
+part of 'nearby_users_bloc.dart';
+
+sealed class NearbyUsersEvent extends Equatable {
+  const NearbyUsersEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadNearbyUsers extends NearbyUsersEvent {}

--- a/lib/features/nearby_users/presentation/bloc/nearby_users_state.dart
+++ b/lib/features/nearby_users/presentation/bloc/nearby_users_state.dart
@@ -1,0 +1,30 @@
+part of 'nearby_users_bloc.dart';
+
+sealed class NearbyUsersState extends Equatable {
+  const NearbyUsersState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+final class NearbyUsersInitial extends NearbyUsersState {}
+
+final class NearbyUsersLoading extends NearbyUsersState {}
+
+final class NearbyUsersLoaded extends NearbyUsersState {
+  final List<NearbyUserSummary> nearbyUsers;
+
+  const NearbyUsersLoaded(this.nearbyUsers);
+
+  @override
+  List<Object?> get props => [nearbyUsers];
+}
+
+final class NearbyUsersError extends NearbyUsersState {
+  final String message;
+
+  const NearbyUsersError(this.message);
+
+  @override
+  List<Object> get props => [message];
+}

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mesh_mobile/common/widgets/button.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mesh_mobile/features/chat/data/chat_repository.dart';
 import 'package:mesh_mobile/features/chat/presentation/bloc/chat_detail_bloc.dart';
 import 'package:mesh_mobile/features/chat/presentation/bloc/chat_list_bloc.dart';
+import 'package:mesh_mobile/features/nearby_users/data/nearby_repository.dart';
+import 'package:mesh_mobile/features/nearby_users/presentation/bloc/nearby_users_bloc.dart';
 import 'package:mesh_mobile/features/register/presentation/bloc/register_bloc.dart';
 import 'package:mesh_mobile/router.dart';
 
@@ -32,7 +34,10 @@ class MeshApp extends StatelessWidget {
           BlocProvider<ChatListBloc>(
               create: (context) =>
                   ChatListBloc(chatRepository: ChatRepository())),
-          BlocProvider<RegisterBloc>(create: (context) => RegisterBloc())
+          BlocProvider<RegisterBloc>(create: (context) => RegisterBloc()),
+          BlocProvider<NearbyUsersBloc>(
+              create: (context) =>
+                  NearbyUsersBloc(nearbyRepository: NearbyRepository())),
         ], child: widget!);
       },
     );


### PR DESCRIPTION
Added nearby devices feature with bloc. Nearby devices is not refreshed only on page refresh, it should listen to nearby device list change event notifications from our core mesh library. Although I haven't added that now, we can do it in the future. It's just adding a listener and refreshing when the event is recieved.

